### PR TITLE
Automatic update of coverlet.collector to 6.0.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -14,7 +14,10 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `coverlet.collector` to `6.0.0` from `3.2.0`
`coverlet.collector 6.0.0` was published at `2023-05-21T13:22:06Z`, 5 months ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `coverlet.collector` `6.0.0` from `3.2.0`

[coverlet.collector 6.0.0 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/6.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
