### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 17.7.2

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `17.7.2` from `17.7.1`
`Microsoft.NET.Test.Sdk 17.7.2` was published at `2023-08-29T08:39:46Z`, 2 months ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `Microsoft.NET.Test.Sdk` `17.7.2` from `17.7.1`

[Microsoft.NET.Test.Sdk 17.7.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.7.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
