### PR TITLE
Automatic update of NUnit.Analyzers to 3.8.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -12,8 +12,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.8.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit.Analyzers` to `3.8.0` from `3.6.1`
`NUnit.Analyzers 3.8.0` was published at `2023-09-25T14:15:42Z`, 23 days ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `NUnit.Analyzers` `3.8.0` from `3.6.1`

[NUnit.Analyzers 3.8.0 on NuGet.org](https://www.nuget.org/packages/NUnit.Analyzers/3.8.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
