### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.16.0.82469

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.15.0.81779" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.16.0.82469" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.16.0.82469` from `9.15.0.81779`
`SonarAnalyzer.CSharp 9.16.0.82469` was published at `2023-12-21T12:42:11Z`, 9 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.16.0.82469` from `9.15.0.81779`

[SonarAnalyzer.CSharp 9.16.0.82469 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.16.0.82469)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
