### PR TITLE
Automatic update of Testcontainers.Kafka to 3.7.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="Testcontainers" Version="3.6.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.6.0" />
-    <PackageReference Include="Testcontainers.Kafka" Version="3.6.0" />
+    <PackageReference Include="Testcontainers.Kafka" Version="3.7.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.6.0" />
   </ItemGroup>
 

--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Testcontainers" Version="3.6.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.6.0" />
-    <PackageReference Include="Testcontainers.Kafka" Version="3.6.0" />
+    <PackageReference Include="Testcontainers.Kafka" Version="3.7.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `Testcontainers.Kafka` to `3.7.0` from `3.6.0`
`Testcontainers.Kafka 3.7.0` was published at `2024-01-09T14:35:20Z`, 11 days ago

2 project updates:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `Testcontainers.Kafka` `3.7.0` from `3.6.0`
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `Testcontainers.Kafka` `3.7.0` from `3.6.0`

[Testcontainers.Kafka 3.7.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers.Kafka/3.7.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
