### PR TITLE
Automatic update of Microsoft.Extensions.Options to 8.0.2

### DIFF
--- a/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
+++ b/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="MediatR" Version="12.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Options` to `8.0.2` from `8.0.1`
`Microsoft.Extensions.Options 8.0.2` was published at `2024-02-13T14:22:10Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj` to `Microsoft.Extensions.Options` `8.0.2` from `8.0.1`

[Microsoft.Extensions.Options 8.0.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Options/8.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
