### PR TITLE
Automatic update of coverlet.collector to 6.0.1

### DIFF
--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -17,7 +17,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Testcontainers" Version="3.7.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.7.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.7.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `coverlet.collector` to `6.0.1` from `6.0.0`
`coverlet.collector 6.0.1` was published at `2024-02-20T21:57:58Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `coverlet.collector` `6.0.1` from `6.0.0`

[coverlet.collector 6.0.1 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/6.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
