### PR TITLE
Automatic update of MongoDB.Driver to 2.24.0

### DIFF
--- a/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
+++ b/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `MongoDB.Driver` to `2.24.0` from `2.23.1`
`MongoDB.Driver 2.24.0` was published at `2024-02-21T18:59:26Z`, 13 days ago

2 project updates:
Updated `HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj` to `MongoDB.Driver` `2.24.0` from `2.23.1`
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `MongoDB.Driver` `2.24.0` from `2.23.1`

[MongoDB.Driver 2.24.0 on NuGet.org](https://www.nuget.org/packages/MongoDB.Driver/2.24.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
