### PR TITLE
Automatic update of EventStore.Client.Grpc.Streams to 23.2.1

### DIFF
--- a/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
+++ b/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.1.0" />
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `EventStore.Client.Grpc.Streams` to `23.2.1` from `23.1.0`
`EventStore.Client.Grpc.Streams 23.2.1` was published at `2024-03-04T13:54:49Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj` to `EventStore.Client.Grpc.Streams` `23.2.1` from `23.1.0`

[EventStore.Client.Grpc.Streams 23.2.1 on NuGet.org](https://www.nuget.org/packages/EventStore.Client.Grpc.Streams/23.2.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
