### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.23.2.88755

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.23.1.88495" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.23.2.88755" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `SonarAnalyzer.CSharp` to `9.23.2.88755` from `9.23.1.88495`
`SonarAnalyzer.CSharp 9.23.2.88755` was published at `2024-04-11T13:14:23Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.23.2.88755` from `9.23.1.88495`

[SonarAnalyzer.CSharp 9.23.2.88755 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.23.2.88755)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
