### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 6.6.2

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.2" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `Swashbuckle.AspNetCore` to `6.6.2` from `6.6.1`
`Swashbuckle.AspNetCore 6.6.2` was published at `2024-05-21T16:46:16Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Swashbuckle.AspNetCore` `6.6.2` from `6.6.1`

[Swashbuckle.AspNetCore 6.6.2 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/6.6.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
