### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.25.1.91650

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.1.91650" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `SonarAnalyzer.CSharp` to `9.25.1.91650` from `9.25.0.90414`
`SonarAnalyzer.CSharp 9.25.1.91650` was published at `2024-05-23T10:24:52Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.25.1.91650` from `9.25.0.90414`

[SonarAnalyzer.CSharp 9.25.1.91650 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.25.1.91650)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
