### PR TITLE
Automatic update of Serilog.Enrichers.Environment to 3.0.0

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Serilog.Enrichers.Environment` to `3.0.0` from `2.3.0`
`Serilog.Enrichers.Environment 3.0.0` was published at `2024-06-09T22:32:11Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Serilog.Enrichers.Environment` `3.0.0` from `2.3.0`

[Serilog.Enrichers.Environment 3.0.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Enrichers.Environment/3.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
