### PR TITLE
Automatic update of Serilog.Enrichers.Thread to 4.0.0

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.1" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Serilog.Enrichers.Thread` to `4.0.0` from `3.1.0`
`Serilog.Enrichers.Thread 4.0.0` was published at `2024-06-14T08:46:08Z`, 13 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Serilog.Enrichers.Thread` `4.0.0` from `3.1.0`

[Serilog.Enrichers.Thread 4.0.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Enrichers.Thread/4.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
