### PR TITLE
Automatic update of OpenTelemetry.Exporter.OpenTelemetryProtocol to 1.9.0

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.0" />
     <PackageReference Include="OpenTelemetry" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `OpenTelemetry.Exporter.OpenTelemetryProtocol` to `1.9.0` from `1.8.1`
`OpenTelemetry.Exporter.OpenTelemetryProtocol 1.9.0` was published at `2024-06-14T20:03:55Z`, 13 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `OpenTelemetry.Exporter.OpenTelemetryProtocol` `1.9.0` from `1.8.1`

[OpenTelemetry.Exporter.OpenTelemetryProtocol 1.9.0 on NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol/1.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
