### PR TITLE
Automatic update of Microsoft.IdentityModel.JsonWebTokens to 7.6.2

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.2" />
     <PackageReference Include="OpenTelemetry" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.IdentityModel.JsonWebTokens` to `7.6.2` from `7.6.0`
`Microsoft.IdentityModel.JsonWebTokens 7.6.2` was published at `2024-06-20T02:31:55Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Microsoft.IdentityModel.JsonWebTokens` `7.6.2` from `7.6.0`

[Microsoft.IdentityModel.JsonWebTokens 7.6.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.IdentityModel.JsonWebTokens/7.6.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
