### PR TITLE
Automatic update of System.IdentityModel.Tokens.Jwt to 7.6.2

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.1" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `System.IdentityModel.Tokens.Jwt` to `7.6.2` from `7.6.0`
`System.IdentityModel.Tokens.Jwt 7.6.2` was published at `2024-06-20T02:32:20Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `System.IdentityModel.Tokens.Jwt` `7.6.2` from `7.6.0`

[System.IdentityModel.Tokens.Jwt 7.6.2 on NuGet.org](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/7.6.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
