### PR TITLE
Automatic update of Testcontainers.Kafka to 3.9.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="RestSharp" Version="111.2.0" />
     <PackageReference Include="Testcontainers" Version="3.8.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.8.0" />
-    <PackageReference Include="Testcontainers.Kafka" Version="3.8.0" />
+    <PackageReference Include="Testcontainers.Kafka" Version="3.9.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.8.0" />
   </ItemGroup>
 

--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Testcontainers" Version="3.8.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.8.0" />
-    <PackageReference Include="Testcontainers.Kafka" Version="3.8.0" />
+    <PackageReference Include="Testcontainers.Kafka" Version="3.9.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.8.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `Testcontainers.Kafka` to `3.9.0` from `3.8.0`
`Testcontainers.Kafka 3.9.0` was published at `2024-06-16T15:33:35Z`, 13 days ago

2 project updates:
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `Testcontainers.Kafka` `3.9.0` from `3.8.0`
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `Testcontainers.Kafka` `3.9.0` from `3.8.0`

[Testcontainers.Kafka 3.9.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers.Kafka/3.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
