### PR TITLE
Automatic update of OpenTelemetry.Exporter.Prometheus.AspNetCore to 1.9.0-beta.2

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `OpenTelemetry.Exporter.Prometheus.AspNetCore` to `1.9.0-beta.2` from `1.7.0-rc.1`
`OpenTelemetry.Exporter.Prometheus.AspNetCore 1.9.0-beta.2` was published at `2024-06-24T20:14:54Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `OpenTelemetry.Exporter.Prometheus.AspNetCore` `1.9.0-beta.2` from `1.7.0-rc.1`

[OpenTelemetry.Exporter.Prometheus.AspNetCore 1.9.0-beta.2 on NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore/1.9.0-beta.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
