### PR TITLE
Automatic update of Serilog.Settings.Configuration to 8.0.2

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.2" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.Settings.Configuration` to `8.0.2` from `8.0.1`
`Serilog.Settings.Configuration 8.0.2` was published at `2024-07-11T23:19:56Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Serilog.Settings.Configuration` `8.0.2` from `8.0.1`

[Serilog.Settings.Configuration 8.0.2 on NuGet.org](https://www.nuget.org/packages/Serilog.Settings.Configuration/8.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
