### PR TITLE
Automatic update of NUnit3TestAdapter to 4.6.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/HomeBudget.Accounting.Api.Tests/HomeBudget.Accounting.Api.Tests.csproj
+++ b/HomeBudget.Accounting.Api.Tests/HomeBudget.Accounting.Api.Tests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit3TestAdapter` to `4.6.0` from `4.5.0`
`NUnit3TestAdapter 4.6.0` was published at `2024-07-25T16:26:45Z`, 7 days ago

3 project updates:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `NUnit3TestAdapter` `4.6.0` from `4.5.0`
Updated `HomeBudget.Accounting.Api.Tests/HomeBudget.Accounting.Api.Tests.csproj` to `NUnit3TestAdapter` `4.6.0` from `4.5.0`
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `NUnit3TestAdapter` `4.6.0` from `4.5.0`

[NUnit3TestAdapter 4.6.0 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/4.6.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
