### PR TITLE
Automatic update of RestSharp to 111.4.1

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RestSharp" Version="111.4.0" />
+    <PackageReference Include="RestSharp" Version="111.4.1" />
     <PackageReference Include="Testcontainers" Version="3.9.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.9.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.9.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `RestSharp` to `111.4.1` from `111.4.0`
`RestSharp 111.4.1` was published at `2024-07-30T07:15:32Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `RestSharp` `111.4.1` from `111.4.0`

[RestSharp 111.4.1 on NuGet.org](https://www.nuget.org/packages/RestSharp/111.4.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
