### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 6.7.0

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `Swashbuckle.AspNetCore` to `6.7.0` from `6.6.2`
`Swashbuckle.AspNetCore 6.7.0` was published at `2024-08-01T10:12:28Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Swashbuckle.AspNetCore` `6.7.0` from `6.6.2`

[Swashbuckle.AspNetCore 6.7.0 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/6.7.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
