### PR TITLE
Automatic update of Microsoft.AspNetCore.Mvc.Testing to 8.0.8

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.Mvc.Testing` to `8.0.8` from `8.0.7`
`Microsoft.AspNetCore.Mvc.Testing 8.0.8` was published at `2024-08-13T12:57:24Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `Microsoft.AspNetCore.Mvc.Testing` `8.0.8` from `8.0.7`

[Microsoft.AspNetCore.Mvc.Testing 8.0.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/8.0.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
