### PR TITLE
Automatic update of Microsoft.AspNetCore.OpenApi to 8.0.8

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.11.1" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.OpenApi` to `8.0.8` from `8.0.7`
`Microsoft.AspNetCore.OpenApi 8.0.8` was published at `2024-08-13T12:57:26Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Microsoft.AspNetCore.OpenApi` `8.0.8` from `8.0.7`

[Microsoft.AspNetCore.OpenApi 8.0.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.OpenApi/8.0.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
