### PR TITLE
Automatic update of Testcontainers.MongoDb to 3.10.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Testcontainers" Version="3.9.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.9.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.9.0" />
-    <PackageReference Include="Testcontainers.MongoDb" Version="3.9.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Testcontainers" Version="3.9.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.9.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.9.0" />
-    <PackageReference Include="Testcontainers.MongoDb" Version="3.9.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Testcontainers.MongoDb` to `3.10.0` from `3.9.0`
`Testcontainers.MongoDb 3.10.0` was published at `2024-09-03T17:52:02Z`, 7 days ago

2 project updates:
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `Testcontainers.MongoDb` `3.10.0` from `3.9.0`
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `Testcontainers.MongoDb` `3.10.0` from `3.9.0`

[Testcontainers.MongoDb 3.10.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers.MongoDb/3.10.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
