### PR TITLE
Automatic update of RestSharp to 112.0.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RestSharp" Version="111.4.1" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.10.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.10.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `RestSharp` to `112.0.0` from `111.4.1`
`RestSharp 112.0.0` was published at `2024-08-29T19:06:42Z`, 12 days ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `RestSharp` `112.0.0` from `111.4.1`

[RestSharp 112.0.0 on NuGet.org](https://www.nuget.org/packages/RestSharp/112.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
