### PR TITLE
Automatic update of EventStore.Client.Grpc.Streams to 23.3.5

### DIFF
--- a/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
+++ b/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.5.3" />
-    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.4" />
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `EventStore.Client.Grpc.Streams` to `23.3.5` from `23.3.4`
`EventStore.Client.Grpc.Streams 23.3.5` was published at `2024-08-29T11:20:54Z`, 12 days ago

1 project update:
Updated `HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj` to `EventStore.Client.Grpc.Streams` `23.3.5` from `23.3.4`

[EventStore.Client.Grpc.Streams 23.3.5 on NuGet.org](https://www.nuget.org/packages/EventStore.Client.Grpc.Streams/23.3.5)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
