### PR TITLE
Automatic update of FluentAssertions to 6.12.1

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/HomeBudget.Accounting.Api.Tests/HomeBudget.Accounting.Api.Tests.csproj
+++ b/HomeBudget.Accounting.Api.Tests/HomeBudget.Accounting.Api.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `FluentAssertions` to `6.12.1` from `6.12.0`
`FluentAssertions 6.12.1` was published at `2024-09-09T14:15:22Z`, 7 days ago

3 project updates:
Updated `HomeBudget.Accounting.Api.Tests/HomeBudget.Accounting.Api.Tests.csproj` to `FluentAssertions` `6.12.1` from `6.12.0`
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `FluentAssertions` `6.12.1` from `6.12.0`
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `FluentAssertions` `6.12.1` from `6.12.0`

[FluentAssertions 6.12.1 on NuGet.org](https://www.nuget.org/packages/FluentAssertions/6.12.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
