### PR TITLE
Automatic update of MediatR to 12.4.1

### DIFF
--- a/HomeBudget.Components.Accounts/HomeBudget.Components.Accounts.csproj
+++ b/HomeBudget.Components.Accounts/HomeBudget.Components.Accounts.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="12.4.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
   </ItemGroup>
 

--- a/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
+++ b/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="MediatR" Version="12.4.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `MediatR` to `12.4.1` from `12.4.0`
`MediatR 12.4.1` was published at `2024-09-09T14:08:35Z`, 7 days ago

2 project updates:
Updated `HomeBudget.Components.Accounts/HomeBudget.Components.Accounts.csproj` to `MediatR` `12.4.1` from `12.4.0`
Updated `HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj` to `MediatR` `12.4.1` from `12.4.0`

[MediatR 12.4.1 on NuGet.org](https://www.nuget.org/packages/MediatR/12.4.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
