### PR TITLE
Automatic update of Microsoft.IdentityModel.JsonWebTokens to 8.1.0

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.2" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.0" />
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.IdentityModel.JsonWebTokens` to `8.1.0` from `8.0.2`
`Microsoft.IdentityModel.JsonWebTokens 8.1.0` was published at `2024-09-24T15:23:10Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Microsoft.IdentityModel.JsonWebTokens` `8.1.0` from `8.0.2`

[Microsoft.IdentityModel.JsonWebTokens 8.1.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.IdentityModel.JsonWebTokens/8.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
