### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 6.8.1

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `Swashbuckle.AspNetCore` to `6.8.1` from `6.7.3`
`Swashbuckle.AspNetCore 6.8.1` was published at `2024-09-30T08:51:36Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Swashbuckle.AspNetCore` `6.8.1` from `6.7.3`

[Swashbuckle.AspNetCore 6.8.1 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/6.8.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
