### PR TITLE
Automatic update of Elastic.Serilog.Sinks to 8.12.1

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.11.1" />
-    <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />
+    <PackageReference Include="Elastic.Serilog.Sinks" Version="8.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Elastic.Serilog.Sinks` to `8.12.1` from `8.11.1`
`Elastic.Serilog.Sinks 8.12.1` was published at `2024-10-03T14:50:25Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Elastic.Serilog.Sinks` `8.12.1` from `8.11.1`

[Elastic.Serilog.Sinks 8.12.1 on NuGet.org](https://www.nuget.org/packages/Elastic.Serilog.Sinks/8.12.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
