### PR TITLE
Automatic update of RestSharp to 112.1.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RestSharp" Version="112.0.0" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.10.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.10.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `RestSharp` to `112.1.0` from `112.0.0`
`RestSharp 112.1.0` was published at `2024-10-04T11:49:43Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `RestSharp` `112.1.0` from `112.0.0`

[RestSharp 112.1.0 on NuGet.org](https://www.nuget.org/packages/RestSharp/112.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
