### PR TITLE
Automatic update of Microsoft.Extensions.DependencyInjection.Abstractions to 8.0.2

### DIFF
--- a/HomeBudget.Components.Categories/HomeBudget.Components.Categories.csproj
+++ b/HomeBudget.Components.Categories/HomeBudget.Components.Categories.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeBudget.Components.Contractors/HomeBudget.Components.Contractors.csproj
+++ b/HomeBudget.Components.Contractors/HomeBudget.Components.Contractors.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
+++ b/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.DependencyInjection.Abstractions` to `8.0.2` from `8.0.1`
`Microsoft.Extensions.DependencyInjection.Abstractions 8.0.2` was published at `2024-10-08T13:18:53Z`, 8 days ago

3 project updates:
Updated `HomeBudget.Components.Categories/HomeBudget.Components.Categories.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `8.0.2` from `8.0.1`
Updated `HomeBudget.Components.Contractors/HomeBudget.Components.Contractors.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `8.0.2` from `8.0.1`
Updated `HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `8.0.2` from `8.0.1`

[Microsoft.Extensions.DependencyInjection.Abstractions 8.0.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
