### PR TITLE
Automatic update of Microsoft.AspNetCore.Mvc.Testing to 8.0.10

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.Mvc.Testing` to `8.0.10` from `8.0.8`
`Microsoft.AspNetCore.Mvc.Testing 8.0.10` was published at `2024-10-08T13:37:16Z`, 8 days ago

1 project update:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `Microsoft.AspNetCore.Mvc.Testing` `8.0.10` from `8.0.8`

[Microsoft.AspNetCore.Mvc.Testing 8.0.10 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/8.0.10)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
