### PR TITLE
Automatic update of System.IdentityModel.Tokens.Jwt to 8.1.2

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `System.IdentityModel.Tokens.Jwt` to `8.1.2` from `8.1.0`
`System.IdentityModel.Tokens.Jwt 8.1.2` was published at `2024-10-08T21:35:25Z`, 8 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `System.IdentityModel.Tokens.Jwt` `8.1.2` from `8.1.0`

[System.IdentityModel.Tokens.Jwt 8.1.2 on NuGet.org](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/8.1.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
