### PR TITLE
Automatic update of Serilog.Settings.Configuration to 8.0.4

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.Settings.Configuration` to `8.0.4` from `8.0.2`
`Serilog.Settings.Configuration 8.0.4` was published at `2024-10-10T00:09:06Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Serilog.Settings.Configuration` `8.0.4` from `8.0.2`

[Serilog.Settings.Configuration 8.0.4 on NuGet.org](https://www.nuget.org/packages/Serilog.Settings.Configuration/8.0.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
