### PR TITLE
Automatic update of Microsoft.AspNetCore.OpenApi to 8.0.10

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.12.1" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.OpenApi` to `8.0.10` from `8.0.8`
`Microsoft.AspNetCore.OpenApi 8.0.10` was published at `2024-10-08T13:37:18Z`, 8 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Microsoft.AspNetCore.OpenApi` `8.0.10` from `8.0.8`

[Microsoft.AspNetCore.OpenApi 8.0.10 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.OpenApi/8.0.10)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
