### PR TITLE
Automatic update of Confluent.Kafka to 2.6.0

### DIFF
--- a/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
+++ b/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.5.3" />
+    <PackageReference Include="Confluent.Kafka" Version="2.6.0" />
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.29.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Confluent.Kafka` to `2.6.0` from `2.5.3`
`Confluent.Kafka 2.6.0` was published at `2024-10-11T22:26:31Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj` to `Confluent.Kafka` `2.6.0` from `2.5.3`

[Confluent.Kafka 2.6.0 on NuGet.org](https://www.nuget.org/packages/Confluent.Kafka/2.6.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
