### PR TITLE
Automatic update of Testcontainers to 4.0.0

### DIFF
--- a/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
+++ b/HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="Testcontainers" Version="3.10.0" />
+    <PackageReference Include="Testcontainers" Version="4.0.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.10.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.10.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />

--- a/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
+++ b/HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Testcontainers" Version="3.10.0" />
+    <PackageReference Include="Testcontainers" Version="4.0.0" />
     <PackageReference Include="Testcontainers.EventStoreDb" Version="3.10.0" />
     <PackageReference Include="Testcontainers.Kafka" Version="3.10.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.10.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Testcontainers` to `4.0.0` from `3.10.0`
`Testcontainers 4.0.0` was published at `2024-11-01T09:08:27Z`, 7 days ago

2 project updates:
Updated `HomeBudget.Accounting.Api.IntegrationTests/HomeBudget.Accounting.Api.IntegrationTests.csproj` to `Testcontainers` `4.0.0` from `3.10.0`
Updated `HomeBudget.Components.Operations.Tests/HomeBudget.Components.Operations.Tests.csproj` to `Testcontainers` `4.0.0` from `3.10.0`

[Testcontainers 4.0.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers/4.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
