### PR TITLE
Automatic update of EventStore.Client.Grpc.Streams to 23.3.7

### DIFF
--- a/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
+++ b/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.6.0" />
-    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.6" />
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `EventStore.Client.Grpc.Streams` to `23.3.7` from `23.3.6`
`EventStore.Client.Grpc.Streams 23.3.7` was published at `2024-11-01T17:14:49Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj` to `EventStore.Client.Grpc.Streams` `23.3.7` from `23.3.6`

[EventStore.Client.Grpc.Streams 23.3.7 on NuGet.org](https://www.nuget.org/packages/EventStore.Client.Grpc.Streams/23.3.7)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
