### PR TITLE
Automatic update of Microsoft.Extensions.Configuration to 9.0.0

### DIFF
--- a/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
+++ b/HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.6.0" />
     <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Configuration` to `9.0.0` from `8.0.0`
`Microsoft.Extensions.Configuration 9.0.0` was published at `2024-11-12T18:13:21Z`, 21 days ago

1 project update:
Updated `HomeBudget.Accounting.Infrastructure/HomeBudget.Accounting.Infrastructure.csproj` to `Microsoft.Extensions.Configuration` `9.0.0` from `8.0.0`

[Microsoft.Extensions.Configuration 9.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
