### PR TITLE
Automatic update of Microsoft.Extensions.Configuration.Binder to 9.0.0

### DIFF
--- a/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
+++ b/HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Configuration.Binder` to `9.0.0` from `8.0.2`
`Microsoft.Extensions.Configuration.Binder 9.0.0` was published at `2024-11-12T18:13:26Z`, 21 days ago

1 project update:
Updated `HomeBudget.Components.Operations/HomeBudget.Components.Operations.csproj` to `Microsoft.Extensions.Configuration.Binder` `9.0.0` from `8.0.2`

[Microsoft.Extensions.Configuration.Binder 9.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Binder/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
