### PR TITLE
Automatic update of Microsoft.IdentityModel.JsonWebTokens to 8.3.0

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.0" />
     <PackageReference Include="OpenTelemetry" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.IdentityModel.JsonWebTokens` to `8.3.0` from `8.2.1`
`Microsoft.IdentityModel.JsonWebTokens 8.3.0` was published at `2024-12-04T18:42:34Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `Microsoft.IdentityModel.JsonWebTokens` `8.3.0` from `8.2.1`

[Microsoft.IdentityModel.JsonWebTokens 8.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.IdentityModel.JsonWebTokens/8.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
