### PR TITLE
Automatic update of System.IdentityModel.Tokens.Jwt to 8.3.0

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `System.IdentityModel.Tokens.Jwt` to `8.3.0` from `8.2.1`
`System.IdentityModel.Tokens.Jwt 8.3.0` was published at `2024-12-04T18:42:59Z`, 7 days ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `System.IdentityModel.Tokens.Jwt` `8.3.0` from `8.2.1`

[System.IdentityModel.Tokens.Jwt 8.3.0 on NuGet.org](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/8.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
