### PR TITLE
Automatic update of OpenTelemetry.Exporter.Prometheus.AspNetCore to 1.10.0-beta.1

### DIFF
--- a/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
+++ b/HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="OpenTelemetry" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `OpenTelemetry.Exporter.Prometheus.AspNetCore` to `1.10.0-beta.1` from `1.9.0-beta.2`
`OpenTelemetry.Exporter.Prometheus.AspNetCore 1.10.0-beta.1` was published at `2024-11-12T22:15:11Z`, 1 month ago

1 project update:
Updated `HomeBudget.Accounting.Api/HomeBudget.Accounting.Api.csproj` to `OpenTelemetry.Exporter.Prometheus.AspNetCore` `1.10.0-beta.1` from `1.9.0-beta.2`

[OpenTelemetry.Exporter.Prometheus.AspNetCore 1.10.0-beta.1 on NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore/1.10.0-beta.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
